### PR TITLE
Make hero and logo stack on width 781px instead of 600px

### DIFF
--- a/src/routes/home/hero/style.css
+++ b/src/routes/home/hero/style.css
@@ -39,7 +39,7 @@
 	text-align: center;
 }
 
-@media (min-width: 600px) {
+@media (min-width: 781px) {
 	.section {
 		flex-direction: row;
 	}


### PR DESCRIPTION
It fixes the logo and text break that we have on some small resolutions

Like this:

<img width="919" alt="screen shot 2017-08-21 at 5 42 42 pm" src="https://user-images.githubusercontent.com/3382153/29529582-2c864c44-8698-11e7-92b2-f5e67ce65fc9.png">

now it should go on two lines (which looks better)

